### PR TITLE
Corrects defaultDistPath in lib/argon2.js

### DIFF
--- a/lib/argon2.js
+++ b/lib/argon2.js
@@ -9,7 +9,7 @@
 }(this, function () {
     'use strict';
 
-    var defaultDistPath = '/node_modules/argon2-browser/docs/dist';
+    var defaultDistPath = '/node_modules/argon2-browser/dist';
 
     /**
      * @enum


### PR DESCRIPTION
`/node_modules/argon2-browser/docs/dist` should be changed to `/node_modules/argon2-browser/dist` if I'm not mistaken.