### PR TITLE
Refactor memory units conversions

### DIFF
--- a/lib/argon2.js
+++ b/lib/argon2.js
@@ -103,14 +103,14 @@
     }
 
     function createWasmMemory(mem) {
-        const KB = 1024 * 1024;
+        const KB = 1024;
         const MB = 1024 * KB;
         const GB = 1024 * MB;
-        const WASM_PAGE_SIZE = 64 * 1024;
+        const WASM_PAGE_SIZE = 64 * KB;
 
-        const totalMemory = (2 * GB - 64 * KB) / 1024 / WASM_PAGE_SIZE;
+        const totalMemory = (2 * GB - 64 * KB) / WASM_PAGE_SIZE;
         const initialMemory = Math.min(
-            Math.max(Math.ceil((mem * 1024) / WASM_PAGE_SIZE), 256) + 256,
+            Math.max(Math.ceil((mem * KB) / WASM_PAGE_SIZE), 256) + 256,
             totalMemory
         );
 


### PR DESCRIPTION
Hi !

This pull request does a minor refactor on how units are used when initializing the WASM memory.
No difference in the computations of `initialMemory` or `totalMemory` though.

Thanks!