### PR TITLE
Cmake warning

### DIFF
--- a/build-wasm.sh
+++ b/build-wasm.sh
@@ -17,7 +17,7 @@ cmake \
     -DCMAKE_EXE_LINKER_FLAGS="-O3 --memory-init-file 0 \
                               -s NO_FILESYSTEM=1 \
                               -s 'EXPORTED_FUNCTIONS=[\"_argon2_hash\",\"_argon2_hash_ext\",\"_argon2_verify\",\"_argon2_verify_ext\",\"_argon2_error_message\",\"_argon2_encodedlen\",\"_malloc\",\"_free\"]' \
-                              -s 'EXTRA_EXPORTED_RUNTIME_METHODS=[\"UTF8ToString\",\"allocate\",\"ALLOC_NORMAL\"]' \
+                              -s 'EXPORTED_RUNTIME_METHODS=[\"UTF8ToString\",\"allocate\",\"ALLOC_NORMAL\"]' \
                               -s DEMANGLE_SUPPORT=0 \
                               -s ASSERTIONS=0 \
                               -s NO_EXIT_RUNTIME=1 \

--- a/build-wasm.sh
+++ b/build-wasm.sh
@@ -14,7 +14,17 @@ cmake \
     -DCMAKE_VERBOSE_MAKEFILE=OFF \
     -DCMAKE_BUILD_TYPE=MinSizeRel \
     -DCMAKE_C_FLAGS="-O3 $ARGON_JS_EXTRA_C_FLAGS" \
-    -DCMAKE_EXE_LINKER_FLAGS="-O3 --memory-init-file 0 -s NO_FILESYSTEM=1 -s 'EXPORTED_FUNCTIONS=[\"_argon2_hash\",\"_argon2_hash_ext\",\"_argon2_verify\",\"_argon2_verify_ext\",\"_argon2_error_message\",\"_argon2_encodedlen\",\"_malloc\",\"_free\"]' -s 'EXTRA_EXPORTED_RUNTIME_METHODS=[\"UTF8ToString\",\"allocate\",\"ALLOC_NORMAL\"]' -s DEMANGLE_SUPPORT=0 -s ASSERTIONS=0 -s NO_EXIT_RUNTIME=1 -s TOTAL_MEMORY=16MB -s BINARYEN_MEM_MAX=2147418112 -s ALLOW_MEMORY_GROWTH=1 -s WASM=1" \
+    -DCMAKE_EXE_LINKER_FLAGS="-O3 --memory-init-file 0 \
+                              -s NO_FILESYSTEM=1 \
+                              -s 'EXPORTED_FUNCTIONS=[\"_argon2_hash\",\"_argon2_hash_ext\",\"_argon2_verify\",\"_argon2_verify_ext\",\"_argon2_error_message\",\"_argon2_encodedlen\",\"_malloc\",\"_free\"]' \
+                              -s 'EXTRA_EXPORTED_RUNTIME_METHODS=[\"UTF8ToString\",\"allocate\",\"ALLOC_NORMAL\"]' \
+                              -s DEMANGLE_SUPPORT=0 \
+                              -s ASSERTIONS=0 \
+                              -s NO_EXIT_RUNTIME=1 \
+                              -s TOTAL_MEMORY=16MB \
+                              -s BINARYEN_MEM_MAX=2147418112 \
+                              -s ALLOW_MEMORY_GROWTH=1 \
+                              -s WASM=1" \
     .
 cmake --build .
 


### PR DESCRIPTION
First commit to add newline for each `-s` option in order to see better the diffs.
Second commit to remove `cmake` warning due to `EXTRA_EXPORTED_RUNTIME_METHODS` turning into `EXPORTED_RUNTIME_METHODS`.