### PR TITLE
Make simd load automatically

### DIFF
--- a/build-wasm.sh
+++ b/build-wasm.sh
@@ -33,5 +33,6 @@ shasum dist/argon2.wasm
 
 perl -pi -e 's/"argon2.js.mem"/null/g' dist/argon2.js
 perl -pi -e 's/$/if(typeof module!=="undefined")module.exports=Module;Module.unloadRuntime=function(){if(typeof self!=="undefined"){delete self.Module}Module=jsModule=wasmMemory=wasmTable=asm=buffer=HEAP8=HEAPU8=HEAP16=HEAPU16=HEAP32=HEAPU32=HEAPF32=HEAPF64=undefined;if(typeof module!=="undefined"){delete module.exports}};/' dist/argon2.js
-perl -pi -e 's/typeof Module!=="undefined"\?Module:\{};/typeof self!=="undefined"&&typeof self.Module!=="undefined"?self.Module:{};var jsModule=Module;/g' dist/argon2.js
+perl -pi -e 's/typeof Module!="undefined"\?Module:\{};/typeof self!=="undefined"&&typeof self.Module!=="undefined"?self.Module:{};var jsModule=Module;/g' dist/argon2.js
 perl -pi -e 's/receiveInstantiatedSource\(output\)\{/receiveInstantiatedSource(output){Module=jsModule;if(typeof self!=="undefined")self.Module=Module;/g' dist/argon2.js
+perl -pi -e 's/argon2.wasm/argon2-simd.wasm/g' dist/argon2.js

--- a/lib/argon2.js
+++ b/lib/argon2.js
@@ -79,15 +79,18 @@
             return global.loadArgon2WasmBinary();
         }
         if (typeof require === 'function') {
-            return Promise.resolve(require('../dist/argon2.wasm')).then(
-                (wasmModule) => {
-                    return decodeWasmBinary(wasmModule);
-                }
+            var simd = require('wasm-feature-detect').simd;
+            return Promise.resolve(
+                simd()
+                    .then((simd) => require('../dist/argon2' + (simd? "-simd" : "") + '.wasm'))
+                    .then((wasmModule) => {
+                        return decodeWasmBinary(wasmModule);
+                    })
             );
         }
         const wasmPath =
             global.argon2WasmPath ||
-            'node_modules/argon2-browser/dist/argon2.wasm';
+            'node_modules/argon2-browser/dist/argon2-simd.wasm';
         return fetch(wasmPath)
             .then((response) => response.arrayBuffer())
             .then((ab) => new Uint8Array(ab));

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,16 @@
 {
     "name": "argon2-browser",
-    "version": "1.18.0",
+    "version": "1.18.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
-            "version": "1.18.0",
+            "name": "argon2-browser",
+            "version": "1.18.1",
             "license": "MIT",
+            "dependencies": {
+                "wasm-feature-detect": "^1.5.1"
+            },
             "devDependencies": {
                 "base64-loader": "^1.0.0",
                 "chai": "^4.3.4",
@@ -2492,6 +2496,11 @@
             "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
             "dev": true
         },
+        "node_modules/wasm-feature-detect": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/wasm-feature-detect/-/wasm-feature-detect-1.5.1.tgz",
+            "integrity": "sha512-GHr23qmuehNXHY4902/hJ6EV5sUANIJC3R/yMfQ7hWDg3nfhlcJfnIL96R2ohpIwa62araN6aN4bLzzzq5GXkg=="
+        },
         "node_modules/watchpack": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.2.0.tgz",
@@ -4829,6 +4838,11 @@
             "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
             "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
             "dev": true
+        },
+        "wasm-feature-detect": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/wasm-feature-detect/-/wasm-feature-detect-1.5.1.tgz",
+            "integrity": "sha512-GHr23qmuehNXHY4902/hJ6EV5sUANIJC3R/yMfQ7hWDg3nfhlcJfnIL96R2ohpIwa62araN6aN4bLzzzq5GXkg=="
         },
         "watchpack": {
             "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "argon2-browser",
-    "version": "1.18.0",
+    "version": "1.18.1",
     "description": "Argon2 library compiled for browser runtime",
     "main": "lib/argon2.js",
     "directories": {
@@ -30,5 +30,8 @@
         "puppeteer": "^9.1.1",
         "webpack": "^5.37.1",
         "webpack-cli": "^4.7.0"
+    },
+    "dependencies": {
+        "wasm-feature-detect": "^1.5.1"
     }
 }


### PR DESCRIPTION
Hi, this PR chages the argon2.js script to check for simd availability via the wasm-feature-detect library, and load the simd-enabled binary if simd support is available.