### PR TITLE
Fix runtime not properly unloading on webpack

### DIFF
--- a/lib/argon2.js
+++ b/lib/argon2.js
@@ -354,6 +354,9 @@
             loadModule._module.unloadRuntime();
             delete loadModule._promise;
             delete loadModule._module;
+            if (typeof require !== 'undefined') {
+                delete require.cache[require.resolve('../dist/argon2.js')]
+            }
         }
     }
 


### PR DESCRIPTION
On Webpack, the cache expects exports on a required module to stay the same. The dist/argon2.js module deletes the export when calling unload runtime. On Webpack builds, if you unload the runtime, and then load it again by doing a hash, the require never resolves.

This PR fixes this behavior by deleting the module form the cache entirely, when unloading the runtime.